### PR TITLE
Add alt text to images

### DIFF
--- a/complete.html
+++ b/complete.html
@@ -461,7 +461,7 @@
                         <div class="col-md-4 p-3 border border-dark-subtle">
                             <div class="fs-5 text-center fw-bolder">Boiled</div>
                             <div class="mt-2">
-                                <img src="./assets/Boiled.jpg" class="img-fluid">
+                                <img src="./assets/Boiled.jpg" alt="Cajun boiled peanuts" class="img-fluid">
                             </div>
                             <div class="mt-2">
                                 <strong>Swamp Nuts Cajun Hot Boiled Peanuts -</strong> With fresh ingredients boiled to
@@ -475,7 +475,7 @@
                         <div class="col-md-4 p-3 border border-dark-subtle">
                             <div class="fs-5 text-center fw-bolder">Sweet</div>
                             <div class="mt-2">
-                                <img src="./assets/Candied.jpg" class="img-fluid">
+                                <img src="./assets/Candied.jpg" alt="Candied peanuts with Cajun spice" class="img-fluid">
                             </div>
                             <div class="mt-2">
                                 <strong>Sweet Swamp Nuts -</strong> We take sugar and <span class="text-danger">Cajun
@@ -490,7 +490,7 @@
                         <div class="col-md-4 p-3 border border-dark-subtle">
                             <div class="fs-5 text-center fw-bolder">Roasted</div>
                             <div class="mt-2">
-                                <img src="./assets/Roasted.jpg" class="img-fluid">
+                                <img src="./assets/Roasted.jpg" alt="Roasted Cajun peanuts" class="img-fluid">
                             </div>
                             <div class="mt-2">
                                 <strong>Roasted Swamp Nuts -</strong> Brined in <span class="text-danger">Cajun
@@ -630,15 +630,15 @@
                     
                     <div class="col-md-4 p-3 align-text-bottom" style="align-items: center;">
                         
-						<img  class="img-fluid" src="./assets/Sacks.jpg">
+						<img  class="img-fluid" src="./assets/Sacks.jpg" alt="Sacks of peanuts ready for boiling">
                     </div>
 					<div class="col-md-4 p-3">
                         
-						<img  class="img-fluid" src="./assets/RollingBoil.jpg">
+						<img  class="img-fluid" src="./assets/RollingBoil.jpg" alt="Peanuts at a rolling boil">
                     </div>
 					<div class="col-md-4 p-3">
                         
-						<img  class="img-fluid" src="./assets/PouringIn.jpg">
+						<img  class="img-fluid" src="./assets/PouringIn.jpg" alt="Pouring peanuts into the pot">
                     </div>
 				
                 </div>
@@ -674,7 +674,7 @@
                             <label for="quantity" class="form-label fs-5 fw-bolder mb-0">Cajun Boiled Peanuts</label>
                             <br/>
                             <div class="pb-2">
-                                <img src="./assets/Boiled.jpg" class="img-fluid">
+                                <img src="./assets/Boiled.jpg" alt="Cajun boiled peanuts" class="img-fluid">
                             </div>
                             <div class="form form-control">
                                 <div>
@@ -688,7 +688,7 @@
                             <label class="form-label fs-5 fw-bolder mb-0">Candied Peanuts</label>
                             <br/>
                             <div class="pb-2">
-                                <img src="./assets/Candied.jpg" class="img-fluid">
+                                <img src="./assets/Candied.jpg" alt="Candied peanuts with Cajun spice" class="img-fluid">
                             </div>
                             <div class="form form-control">
                                 <div>
@@ -711,7 +711,7 @@
                             <label class="form-label fs-5 fw-bolder mb-0">Roasted Peanuts</label>
                             <br/>
                             <div class="pb-2">
-                                <img src="./assets/Roasted.jpg" class="img-fluid">
+                                <img src="./assets/Roasted.jpg" alt="Roasted Cajun peanuts" class="img-fluid">
                             </div>
                             <div>
 

--- a/index.html
+++ b/index.html
@@ -352,15 +352,15 @@
                     
                     <div class="col-md-4 p-3 align-text-bottom" style="align-items: center;">
                         
-						<img  class="img-fluid productLineupImage" src="./assets/Sacks.jpg"/>
+						<img  class="img-fluid productLineupImage" src="./assets/Sacks.jpg" alt="Sacks of peanuts ready for boiling"/>
                     </div>
 					<div class="col-md-4 p-3">
                         
-						<img  class="img-fluid productLineupImage" src="./assets/RollingBoil.jpg"/>
+						<img  class="img-fluid productLineupImage" src="./assets/RollingBoil.jpg" alt="Peanuts at a rolling boil"/>
                     </div>
 					<div class="col-md-4 p-3">
                         
-						<img  class="img-fluid productLineupImage" src="./assets/PouringIn.jpg"/>
+						<img  class="img-fluid productLineupImage" src="./assets/PouringIn.jpg" alt="Pouring peanuts into the pot"/>
                     </div>
 				
                 </div>


### PR DESCRIPTION
## Summary
- add meaningful alt text to several `<img>` tags in `index.html` and `complete.html`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c1bb11518832eaa66991e57e29cbb