### PR TITLE
Implement brand color palette

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,0 +1,31 @@
+:root {
+    --brand-primary: #2A5B36;
+    --brand-secondary: #FFB729;
+    --brand-accent: #B23121;
+    --brand-neutral: #F4E9D8;
+    --brand-dark-neutral: #5C3A21;
+}
+
+.btn-brand-primary {
+    color: #fff;
+    background-color: var(--brand-primary);
+    border-color: var(--brand-primary);
+}
+.btn-brand-primary:hover,.btn-brand-primary:focus{filter:brightness(0.9);}
+
+.btn-brand-secondary {
+    color: #000;
+    background-color: var(--brand-secondary);
+    border-color: var(--brand-secondary);
+}
+.btn-brand-accent {
+    color: #fff;
+    background-color: var(--brand-accent);
+    border-color: var(--brand-accent);
+}
+
+.alert-brand {
+    background-color: var(--brand-secondary);
+    border-color: var(--brand-accent);
+    color: #000;
+}

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -11,17 +11,31 @@
     background-color: var(--brand-primary);
     border-color: var(--brand-primary);
 }
-.btn-brand-primary:hover,.btn-brand-primary:focus{filter:brightness(0.9);}
+.btn-brand-primary:hover,
+.btn-brand-primary:focus {
+    filter: brightness(0.9);
+    color: #fff;
+}
 
 .btn-brand-secondary {
     color: #000;
     background-color: var(--brand-secondary);
     border-color: var(--brand-secondary);
 }
+.btn-brand-secondary:hover,
+.btn-brand-secondary:focus {
+    filter: brightness(0.9);
+    color: #000;
+}
 .btn-brand-accent {
     color: #fff;
     background-color: var(--brand-accent);
     border-color: var(--brand-accent);
+}
+.btn-brand-accent:hover,
+.btn-brand-accent:focus {
+    filter: brightness(0.9);
+    color: #fff;
 }
 
 .alert-brand {

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="./assets/styles/main.css">
  
     <meta name='keywords' content="Prairieville, Ascension parish, louisiana, peanuts, boiled peanuts, hot boiled peanuts, cajun, cajun peanuts, cajun boiled peanuts, swamp nuts, nuts, boiled nuts, candied peanuts, roasted peanuts">
     <meta name='description' content="Swamp Nuts - Cajun Hot Boiled Peanuts, Cajun Candied Peanuts, Cajun Roasted Peanuts">
@@ -164,7 +165,7 @@
 
         <div class="d-md-inline-block mt-2 d-flex shutdown">
             <a href="#orderform" title="Order Online"
-               class=" btn btn-dark text-uppercase d-inline-flex ">
+               class="btn btn-brand-primary text-uppercase d-inline-flex">
                 <strong class="d-block">
                     Order Online
                 </strong>
@@ -180,7 +181,7 @@
             <div class="intro-section">
                 <h1 class="display-4 mb-3">Welcome to Swamp Nuts!</h1>
                 <p class="lead">Bringing you authentic Cajun-inspired boiled and roasted peanuts, crafted with care and passion for bold, irresistible flavors. Experience the taste of Southern tradition from Prairieville, Louisiana.</p>
-                <div class="shutdown-message" style="margin-top: 1.5rem; padding: 1rem; background-color: #fff3cd; border: 1px solid #ffeeba; border-radius: 0.25rem; text-align: center;">
+                <div class="shutdown-message alert-brand" style="margin-top: 1.5rem; padding: 1rem; border-radius: 0.25rem; text-align: center;">
                     🌞 We're closed for the summer!<br>
                     Swamp Nuts will reopen in early fall at the Riverside Farmers Market.<br>
                     Follow us on <a href="https://www.facebook.com/swampnuts.biz" target="_blank"><strong>Facebook</strong></a> for updates.
@@ -211,7 +212,7 @@
                                 looking to experience a true Cajun classic.
                             </div>
                             <div class="mt-2 shutdown">
-                                <a href="#orderform" class="btn btn-success">Order Now</a>
+                                <a href="#orderform" class="btn btn-brand-primary">Order Now</a>
                             </div>
 
                         </div>
@@ -229,7 +230,7 @@
                                 packed with Southern character.
                             </div>
                             <div class="mt-2">
-                                <a href="#orderform" class="btn btn-success shutdown">Order Now</a>
+                                <a href="#orderform" class="btn btn-brand-primary shutdown">Order Now</a>
                             </div>
                         </div>
                     </div>
@@ -395,7 +396,7 @@
                                 <b class="text-danger">Free delivery to Prairieville, Galvez, Gonzales & nearby areas.</b> Orders placed after 6 PM will be delivered next day.
                             </p>
                             <div>
-                                <button class="btn btn-primary w-100"  onclick="deliverySelected()">Select Local Delivery</button>
+                                <button class="btn btn-brand-primary w-100" onclick="deliverySelected()">Select Local Delivery</button>
                             </div>
                         </div>
                     </div>
@@ -413,7 +414,7 @@
                                 <b class="text-danger">Orders under $20 will incur a $3 shipping fee.</b>
                             </p>
                             <div>
-                                <button class="btn btn-secondary w-100" onclick="shippingSelected()" >Select Shipping</button>
+                                <button class="btn btn-brand-secondary w-100" onclick="shippingSelected()" >Select Shipping</button>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- create `main.css` with brand color variables and button/alert styles
- include the stylesheet in `index.html`
- apply brand button classes to order and shipping buttons
- improve shutdown banner with the new alert style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c213a1338832e90bfbd3b7637fefa